### PR TITLE
Fixed same day event bug

### DIFF
--- a/js/eventScript.js
+++ b/js/eventScript.js
@@ -22,19 +22,28 @@ $.getJSON(eventsURL)
     populateEvents(data);
   })
   .fail(function(a, b, c){ //When fail contact me or link to github to submit pull request
+    jsonRetrieveError(c);
   });
+
+function jsonRetrieveError(err){
+  var upcoming = document.getElementById('upcoming');
+  upcoming.innerHTML = "Error retrieving JSON. Please contact the webmaster"
+  console.log("Request to '"+eventsURL+"' failed. Error: "+err);
+}
       
 function populateEvents(EventsJSON){
+  var today = new Date();
+  today.setHours(0,0,0,0); //Necessary to make same day events show up
   for (var i=0; i < EventsJSON.length; i++){  //Loop through events
     var eventElement = newEvent(EventsJSON[i])
     var eventDate = new Date(EventsJSON[i]['date']);
-    var today = new Date();
+    eventDate.setHours(0,0,0,0);
     var upcoming = document.getElementById('upcoming');
     var past = document.getElementById('past');
-    if(eventDate.getTime() > today.getTime()){
-      upcoming.insertBefore(eventElement, upcoming.firstChild);
-    } else {
+    if(eventDate.getTime() < today.getTime()){
       past.appendChild(eventElement);
+    } else {
+      upcoming.insertBefore(eventElement, upcoming.firstChild);
     }
   }
 }

--- a/js/events.json
+++ b/js/events.json
@@ -510,7 +510,7 @@
   "title_url":"",
   "link_type": 0,
   "date_string":"March 23rd",
-  "date":"March 23rd 2016",
+  "date":"March 23 2016",
   "time":"",
   "location":"",
   "location_url":"",


### PR DESCRIPTION
Events that occurred on the current day would display as
past events previously. This should be fixed

One event in the JSON wasn't parseable as it was
March 23rd instead of March 23.

Added output if the json can't be fetched